### PR TITLE
Fixed NaN issue in cleanAprStats

### DIFF
--- a/src/model/PickleModel.ts
+++ b/src/model/PickleModel.ts
@@ -722,16 +722,15 @@ export class PickleModel {
 
     cleanAprStats(stats: AssetProjectedApr) : AssetProjectedApr{
         if( stats ) {
-            stats.apr = toThreeDec(stats.apr);
-            stats.apy = toThreeDec(stats.apy);
             if( stats.components) {
                 for( let i = 0; i < stats.components.length; i++ ) {
-                    stats.components[i].apr = toThreeDec(stats.components[i].apr);
+                    stats.components[i].apr = toThreeDec(stats.components[i].apr ? stats.components[i].apr:0);
                     if( stats.components[i].maxApr)
-                        stats.components[i].maxApr = toThreeDec(stats.components[i].maxApr);
-                    
+                        stats.components[i].maxApr = toThreeDec(stats.components[i].maxApr ? stats.components[i].maxApr:0);
                 }
             }
+            stats.apr = toThreeDec(stats.apr ? stats.apr:0);
+            stats.apy = toThreeDec(stats.apy ? stats.apy:0);
         }
         return stats;
     }


### PR DESCRIPTION
src/model/PickleModel.ts function cleanAprStats did not have any null check before running the function toThreeDec on values. If the value was null or NaN this resulted in pf-core failing to produce an output. I have corrected the lines of code where toThreeDec is called to, in the event the argument is null or NaN, will simply return zero so the rest of the output can still be produced and the site does not die.