### PR TITLE
Correct jar underlying USD calculation

### DIFF
--- a/src/behavior/AbstractJarBehavior.ts
+++ b/src/behavior/AbstractJarBehavior.ts
@@ -99,7 +99,6 @@ export abstract class AbstractJarBehavior implements JarBehavior {
       model,
       resolver,
     );
-    const balanceWithAvailable = balance.add(available);
     const depositTokenDecimals = definition.depositToken.decimals
       ? definition.depositToken.decimals
       : 18;
@@ -108,7 +107,7 @@ export abstract class AbstractJarBehavior implements JarBehavior {
     );
     const balanceUSD: number =
       parseFloat(
-        ethers.utils.formatUnits(balanceWithAvailable, depositTokenDecimals),
+        ethers.utils.formatUnits(balance, depositTokenDecimals),
       ) * depositTokenPrice;
     const availUSD: number =
       parseFloat(ethers.utils.formatUnits(available, depositTokenDecimals)) *

--- a/src/behavior/impl/metis-hades-jar.ts
+++ b/src/behavior/impl/metis-hades-jar.ts
@@ -1,4 +1,4 @@
-import { ethers, Signer } from "ethers";
+import { Signer } from "ethers";
 import { sushiStrategyAbi } from "../../Contracts/ABIs/sushi-strategy.abi";
 import { Provider } from "@ethersproject/providers";
 import { PickleModel } from "../..";

--- a/src/behavior/impl/metis-netswap-jar.ts
+++ b/src/behavior/impl/metis-netswap-jar.ts
@@ -1,4 +1,4 @@
-import { ethers, Signer } from "ethers";
+import { Signer } from "ethers";
 import fetch from "cross-fetch";
 import { Provider } from "@ethersproject/providers";
 import { Chains, PickleModel } from "../..";

--- a/src/behavior/impl/raider-jar.ts
+++ b/src/behavior/impl/raider-jar.ts
@@ -2,17 +2,14 @@ import { Signer } from "ethers";
 import { Provider } from "@ethersproject/providers";
 import { sushiStrategyAbi } from "../../Contracts/ABIs/sushi-strategy.abi";
 import {
-  AssetAprComponent,
   AssetProjectedApr,
   JarDefinition,
 } from "../../model/PickleModelJson";
 import { Contract as MulticallContract } from "ethers-multicall";
 import {
   AbstractJarBehavior,
-  createAprComponentImpl,
 } from "../AbstractJarBehavior";
 import { PickleModel } from "../../model/PickleModel";
-import { calculateFossilFarmsAPY } from "../../protocols/DinoUtil";
 import { SushiPolyPairManager } from "../../protocols/SushiSwapUtil";
 import raiderRewardsAbi from "../../Contracts/ABIs/raider-rewards.json";
 import { formatEther } from "ethers/lib/utils";

--- a/src/behavior/impl/tethys-jar.ts
+++ b/src/behavior/impl/tethys-jar.ts
@@ -1,5 +1,4 @@
-import { ethers, Signer } from "ethers";
-import fetch from "cross-fetch";
+import { Signer } from "ethers";
 import { Provider } from "@ethersproject/providers";
 import { PickleModel } from "../..";
 import { JarDefinition, AssetProjectedApr } from "../../model/PickleModelJson";

--- a/src/behavior/impl/univ3-usdc-eth.ts
+++ b/src/behavior/impl/univ3-usdc-eth.ts
@@ -12,7 +12,6 @@ import { AbstractJarBehavior } from "../AbstractJarBehavior";
 import jarV3Abi from "../../Contracts/ABIs/jar-v3.json";
 import {
   calculateFee,
-  calculateLiquidity,
   getLiquidityForAmounts,
   getSqrtPriceX96,
   getTickFromPrice,
@@ -154,7 +153,7 @@ export class Uni3UsdcEth extends AbstractJarBehavior {
       amount1,
       Number(tokenA.decimals.toFixed() || 18),
     );
-    let currentTick = getTickFromPrice(
+    const currentTick = getTickFromPrice(
       token1Price,
       tokenA.decimals.toFixed() || "18",
       tokenB.decimals.toFixed() || "18",

--- a/src/graph/TheGraph.ts
+++ b/src/graph/TheGraph.ts
@@ -66,6 +66,7 @@ export function graphUrlFromDetails(protocol: AssetProtocol, chain: ChainNetwork
       switch(chain) {
         case ChainNetwork.Polygon: return SUBGRAPH_URL_UNISWAP_V3_POLYGON; 
       }
+      break;
     }
     case AssetProtocol.COMETHSWAP: return SUBGRAPH_URL_COMETH;
     case AssetProtocol.QUICKSWAP: return SUBGRAPH_URL_QUICKSWAP;

--- a/src/model/PickleModel.ts
+++ b/src/model/PickleModel.ts
@@ -635,7 +635,7 @@ export class PickleModel {
         let balanceOfProm : Promise<BigNumber[]> = undefined; 
         try {
             balanceOfProm = multicallProvider.all<BigNumber[]>(
-                harvestableJars.map((oneJar) => new MulticallContract(oneJar.details.strategyAddr, strategyAbi).balanceOf())
+                harvestableJars.map((oneJar) => new MulticallContract(oneJar.contract, jarAbi).balance())
             );
         } catch ( error ) { this.logError("loadHarvestDataJarAbi: balanceOfProm", error, chain); }
 

--- a/src/protocols/Univ3/LiquidityMath.ts
+++ b/src/protocols/Univ3/LiquidityMath.ts
@@ -38,8 +38,8 @@ export const calculateLiquidity = (ticks: Tick[], currentTick: number): bn => {
   for (let i = 0; i < ticks.length - 1; ++i) {
     liquidity = liquidity.plus(new bn(ticks[i].liquidityNet));
 
-    let lowerTick = Number(ticks[i].tickIdx);
-    let upperTick = Number(ticks[i + 1].tickIdx);
+    const lowerTick = Number(ticks[i].tickIdx);
+    const upperTick = Number(ticks[i + 1].tickIdx);
 
     if (lowerTick <= currentTick && currentTick <= upperTick) {
       break;


### PR DESCRIPTION
### Issue
Bug identified in relation to an incorrect underlying LOOKS token value in USD.

### Fix
This patch use of `available` in calculating balanceUSD. `available` only represents a fraction of the number of `want` tokens in the jar, (see https://github.com/pickle-finance/protocol/blob/master/src/pickle-jar.sol#L69). 

On the other hand, the `balance` property of the jar takes into account everything sitting in the jar, the strategy, and what the strategy has staked (see https://github.com/pickle-finance/protocol/blob/master/src/pickle-jar.sol#L39) and when simply multiplied by the price of the underlying token, will yield the total USD balance of the jar. 

Image # 1 shows that adding up `available` of the jar (right) and the `balanceOf` the strategy (left) does not yield the total `balance` of the jar.

Image # 2 shows that the math now checks out for the LOOKS USD value.

![image](https://user-images.githubusercontent.com/71284258/150229054-e072685b-373d-4d3c-aa30-34e8c7ec27b0.png)
![image](https://user-images.githubusercontent.com/71284258/150229064-c5b1a4b4-8882-4cf9-971f-9aa3d6e6e98f.png)
