### PR TITLE
Use correct minichef userInfo index for fetching user balance

### DIFF
--- a/src/client/UserModel.ts
+++ b/src/client/UserModel.ts
@@ -377,7 +377,7 @@ export class UserModel {
       if (ind === -1) {
         ret.push(BigNumber.from(0));
       } else {
-        ret.push(userInfos[ind][1].toString());
+        ret.push(userInfos[ind][0].toString());
       }
     }
     return ret;


### PR DESCRIPTION
`userInfo[1]` returns the `rewardDebt`, which is not the `amount` we're looking for (provided by `userInfo[0]`).